### PR TITLE
Addition of Meshkov force model

### DIFF
--- a/include/force.h
+++ b/include/force.h
@@ -5,7 +5,7 @@
 #include <cmath>
 #include "constants.h"
 
-enum class ForceFormula {PARKHOMCHUK,DERBENEVSKRINSKY};//,MESHKOV,BUDKER,ERLANGEN};
+enum class ForceFormula {PARKHOMCHUK,DERBENEVSKRINSKY,MESHKOV}; //BUDKER,ERLANGEN};
 
 class ForceParas{
  protected:
@@ -96,6 +96,22 @@ class Force_DS : public ForceParas{
     
 };
 
+class Force_Meshkov : public ForceParas{
+    private:
+    //Force-dependent constants
+        //The factor of pi/2 comes from the difference between the constants
+        // used in Parkhomchuk with the constants used in the Meshkov representation
+        //const double f_const = -4 * (k_pi/2) * k_me_kg * pow(k_re*k_c*k_c,2); 
+        //const char* test_filename = "Meshkov.txt";
+        double k_ = 2;
+    public:
+        Force_Meshkov():ForceParas(ForceFormula::MESHKOV,-4 * (k_pi/2) * k_me_kg * pow(k_re*k_c*k_c,2),"Meshkov.txt"){};
+    
+        int set_k(double k){k_ = k; return 0;}
+        virtual void force(double v_tr, double v_long, double d_perp_e, double d_paral_e, double temperature,
+                           int charge_number, double density_e,double time_cooler,double magnetic_field, 
+                           double &force_result_trans, double &force_result_long);
+};
 
 int friction_force(int charge_number, unsigned long int ion_number, double *v_tr, double *v_z, double *density_e,
                   ForceParas &force_paras, double *force_tr, double *force_long);

--- a/src/force.cc
+++ b/src/force.cc
@@ -19,8 +19,16 @@ int ForceParas::ApplyForce(int charge_number, unsigned long int ion_number, doub
                             double temperature, double magnetic_field, double *d_perp_e, double *d_paral_e, double time_cooler,
                             double *force_tr, double *force_long) {
 
-//Compiler should ignore #pragma it doesn't understand
+//This function definition differs from the next only in the definition
+// of d_perp_e or d_paral_e as double or double*.  The other implementation
+// is the only one currently called by our testing suite
+    
+    
+//Compiler should ignore #pragma it doesn't understand, but we'll place a condition
+// so OpenMP can be easily turned off for debugging
+#ifdef _OPENMP
     #pragma omp parallel for  
+#endif
     for(unsigned long int i=0; i<ion_number; ++i){
         double result_trans,result_long;
         force(v_tr[i],v_long[i],d_perp_e[i],d_paral_e[i],temperature,charge_number,
@@ -37,8 +45,9 @@ int ForceParas::ApplyForce(int charge_number, unsigned long int ion_number, doub
                             double temperature, double magnetic_field, double d_perp_e, double d_paral_e, double time_cooler,
                             double *force_tr, double *force_long, bool do_test) {
     
-//Compiler should ignore #pragma it doesn't understand
-    #pragma omp parallel for //ordered schedule(dynamic,10)
+#ifdef _OPENMP
+    #pragma omp parallel for 
+#endif
     for(unsigned long int i=0; i<ion_number; ++i){
         double result_trans,result_long;
         force(v_tr[i],v_long[i],d_perp_e,d_paral_e,temperature,charge_number,
@@ -114,44 +123,10 @@ void Force_Parkhomchuk::force(double v_tr, double v_long, double d_perp_e, doubl
     force_result_trans = force * v_tr;
     force_result_long = force * v_long;
 
-/*  
-    double f_con = -4*k_c*k_c*k_ke*k_ke*k_e*k_e*k_e/(k_me*1e6);
-    double v2_eff_e = temperature*k_c*k_c/(k_me*1e6);
-    double wp_const = 4*k_pi*k_c*k_c*k_e*k_ke/(k_me*1e6);
-    double rho_min_const = charge_number*k_e*k_ke*k_c*k_c/(k_me*1e6);
-    
-    double dlt2_eff_e = d_paral_e*d_paral_e+v2_eff_e;
-    double rho_lamor = k_me*1e6*d_perp_e/(magnetic_field*k_c*k_c);
-    
-    double v2 = v_tr*v_tr+v_long*v_long;
-    if(v2>0){
-        double dlt = v2+dlt2_eff_e;
-        //Calculate rho_min
-        double rho_min = rho_min_const/dlt;
-        dlt = sqrt(dlt);
-        double wp = sqrt(wp_const*density_e);
-
-        //Calculate rho_max
-        double rho_max = dlt/wp;
-        double rho_max_2 = pow(3*charge_number/density_e, 1.0/3);
-        if(rho_max<rho_max_2) rho_max = rho_max_2;
-        double rho_max_3 = dlt*time_cooler;
-        if(rho_max>rho_max_3) rho_max = rho_max_3;
-
-        double lc = log((rho_max+rho_min+rho_lamor)/(rho_min+rho_lamor));   //Coulomb Logarithm =~5
-        std::cout<<lc<<std::endl;
-        //Calculate friction force
-        double f = f_con*density_e*lc/(dlt*dlt*dlt);
-        force_result_trans = f*v_tr;
-        force_result_long = f*v_long;
-    }
-    else{
-        force_result_trans = 0;
-        force_result_long = 0;
-    }
-*/
 }    
 
+
+//Abstracted functions for the GSL integration
 double Force_DS::trans_integrand(double alpha,void *params){
     //Using Pestrikov's trick to change the integration variable
 
@@ -207,7 +182,6 @@ void Force_DS::EvalIntegral(double (*func)(double, void*), int_info &params,doub
   
 }
 
-//This function is used for calculating the forces on single particles or arrays of particles
 void Force_DS::force(double v_tr, double v_long, double d_perp_e, double d_paral_e, double temperature,
                      int charge_number,double density_e,double time_cooler,double magnetic_field, 
                      double &force_result_tr, double &force_result_long){
@@ -240,6 +214,85 @@ void Force_DS::force(double v_tr, double v_long, double d_perp_e, double d_paral
           
 }
 
+void Force_Meshkov::force(double v_tr, double v_long, double d_perp_e, double d_paral_e, double temperature,
+                          int charge_number,double density_e,double time_cooler,double magnetic_field,
+                          double &force_result_trans, double &force_result_long){
+    
+  double rho_L    = k_me_kg * d_perp_e / ( magnetic_field * k_e ); //SI units, in m
+  double wp_const = 4 * k_pi * k_c*k_c * k_re;
+  double wp       = sqrt(wp_const * density_e);
+    
+  //A fudge factor to smooth the friction force shape. Using the
+  // "Classical" default definition here from the BETACOOL documentation
+  double k = 2;
+
+  //double rho_min_const = charge_number * k_e*k_e * k_c*k_c / (k_me * 1e6); //CGS units
+  double rho_min_const = charge_number * k_re * k_c*k_c; //SI units
+    
+  double v2      = v_tr*v_tr + v_long*v_long;
+  double v3      = pow(sqrt(v2),3);
+
+  //The Number of multiple adiabatic collisions with a single electron
+  double N_col = 1 + d_perp_e/(k_pi*sqrt(v2 + d_paral_e*d_paral_e));
+      
+  //dynamic shielding radius
+  double rho_sh = sqrt(v2 + d_paral_e*d_paral_e) / wp;
+  //minimum impact parameter  
+  double rho_min = rho_min_const / (v2 + d_paral_e*d_paral_e);  //in units of m
+  //intermediate impact parameter
+  double rho_F = rho_L * sqrt(v2 + d_paral_e*d_paral_e) / d_perp_e;
+  
+  double rho_max = max_impact_factor(sqrt(v2 + d_paral_e*d_paral_e),charge_number,density_e,time_cooler);
+
+  //Coulomb Logarithms
+  double L_M = log(rho_max / (k*rho_L)); //there's a typo in the BETACOOL guide, the numerator here is rho_max
+  double L_A = log((k*rho_L) / rho_F);
+  double L_F = log(rho_F / rho_min);
+
+  //std::cout<<"Meshkov: L_M="<<L_M<<" L_A="<<L_A<<" L_F="<<L_F<<std::endl;
+
+  //If it's < 0, the interaction is absent
+  if( L_M < 1. ) L_M = 0.0; //This controls the low ion V_long rise, ~10-20
+  if( L_A < 1. ) L_A = 0.0; 
+  if( L_F < 1. ) L_F = 0.0;  //This one is responsible for discontinuity at high ion V_long ~5.5
+    
+  //Define the regions of the ion velocity domains
+  double result_trans,result_long;
+    
+  double ellipse = (v_tr*v_tr)/(d_perp_e*d_perp_e) + (v_long*v_long)/(d_paral_e*d_paral_e);
+     
+  if(sqrt(v2) > d_perp_e) { //Region I
+       result_trans = 2*L_F + L_M*(v_tr*v_tr - 2*v_long*v_long)/v2;
+       result_trans /= v3;
+         
+        result_long = 2 + 2*L_F + L_M*(3*v_tr*v_tr/v2);
+        result_long /= v3;
+  }   
+  else if(sqrt(v2) < d_paral_e) { //Region III
+        result_trans = 2*(L_F + N_col*L_A)/pow(d_perp_e,3) + L_M/pow(d_paral_e,3);
+        result_long = 2*(L_F + N_col*L_A)/(d_perp_e*d_perp_e * d_paral_e) + L_M/pow(d_paral_e,3);
+      }  
+
+  //Region II (a or b)
+  else{ //This constrains to a donut shape (d_paral_e < sqrt(v2) < d_perp_e).
+        result_trans = ((v_tr*v_tr - 2*v_long*v_long)/v2) * (L_M/v3);
+        result_trans += (2/pow(d_perp_e,3)) * (L_F + N_col*L_A);
+          
+        if( ellipse <= 1.0 ){ // Region IIb
+              //This is the same as result_long in Region 3 
+              result_long = 2*(L_F + N_col*L_A)/(d_perp_e*d_perp_e * d_paral_e) + L_M/pow(d_paral_e,3);
+        }
+        else{ //It must be Region IIa
+              result_long = (((3*v_tr*v_tr*L_M)/v2) + 2) / v3;
+              result_long += 2 * (L_F + N_col*L_A)/(d_perp_e*d_perp_e * v_long);
+        }
+  } 
+        
+  //The factor of pi/2 comes from the difference between the constants
+  // used in Parkhomchuk with the constants used in the Meshkov representation
+  force_result_trans = f_const_ * charge_number*charge_number * density_e * result_trans * v_tr;
+  force_result_long = f_const_ * charge_number*charge_number * density_e * result_long * v_long;
+}
 
     
 int friction_force(int charge_number, unsigned long int ion_number, double *v_tr, double *v_long, double *density_e,
@@ -280,6 +333,11 @@ ForceParas* ChooseForce(ForceFormula force_formula){
         case(ForceFormula::DERBENEVSKRINSKY):
             force_paras = new Force_DS();
             break;
+            
+        case(ForceFormula::MESHKOV):
+            force_paras = new Force_Meshkov();
+            break;
+
 
     }
     return force_paras;

--- a/src/force.cc
+++ b/src/force.cc
@@ -252,9 +252,9 @@ void Force_Meshkov::force(double v_tr, double v_long, double d_perp_e, double d_
   //std::cout<<"Meshkov: L_M="<<L_M<<" L_A="<<L_A<<" L_F="<<L_F<<std::endl;
 
   //If it's < 0, the interaction is absent
-  if( L_M < 1. ) L_M = 0.0; //This controls the low ion V_long rise, ~10-20
-  if( L_A < 1. ) L_A = 0.0; 
-  if( L_F < 1. ) L_F = 0.0;  //This one is responsible for discontinuity at high ion V_long ~5.5
+  if( L_M < 0. ) L_M = 0.0; //This controls the low ion V_long rise, ~10-20
+  if( L_A < 0. ) L_A = 0.0; 
+  if( L_F < 0. ) L_F = 0.0;  //This one is responsible for discontinuity at high ion V_long ~5.5
     
   //Define the regions of the ion velocity domains
   double result_trans,result_long;

--- a/src/ui.cc
+++ b/src/ui.cc
@@ -52,7 +52,7 @@ std::vector<string> E_BEAM_ARGS = {"GAMMA", "TMP_TR", "TMP_L", "SHAPE", "RADIUS"
     "SIGMA_Z", "LENGTH", "E_NUMBER", "RH", "RV", "R_INNER", "R_OUTTER", "PARTICLE_FILE", "TOTAL_PARTICLE_NUMBER",
     "BOX_PARTICLE_NUMBER", "LINE_SKIP", "VEL_POS_CORR","BINARY_FILE","BUFFER_SIZE"};
 std::vector<string> ECOOL_ARGS = {"SAMPLE_NUMBER", "FORCE_FORMULA"};
-std::vector<string> FRICTION_FORCE_FORMULA = {"PARKHOMCHUK", "DERBENEVSKRINSKY"};//,"MESHKOV","BUDKER","ERLANGEN"};
+std::vector<string> FRICTION_FORCE_FORMULA = {"PARKHOMCHUK", "DERBENEVSKRINSKY","MESHKOV"};//,"BUDKER","ERLANGEN"};
 std::vector<string> SIMULATION_ARGS = {"TIME", "STEP_NUMBER", "SAMPLE_NUMBER", "IBS", "E_COOL", "OUTPUT_INTERVAL",
     "SAVE_PARTICLE_INTERVAL", "OUTPUT_FILE", "MODEL", "REF_BET_X", "REF_BET_Y", "REF_ALF_X", "REF_ALF_Y",
     "REF_DISP_X", "REF_DISP_Y", "REF_DISP_DX", "REF_DISP_DY", "FIXED_BUNCH_LENGTH", "RESET_TIME", "OVERWRITE",
@@ -1373,6 +1373,7 @@ void set_ecool(string &str, Set_ecool *ecool_args){
     if (var == "FORCE_FORMULA") {
         if (val=="PARKHOMCHUK") ecool_args->force = ForceFormula::PARKHOMCHUK;
         else if (val=="DERBENEVSKRINSKY") ecool_args->force = ForceFormula::DERBENEVSKRINSKY;
+        else if (val=="MESHKOV") ecool_args->force = ForceFormula::MESHKOV;
         
         else assert(false&&"Friction force formula NOT exists!");
     }

--- a/tests/test_eic.cc
+++ b/tests/test_eic.cc
@@ -325,6 +325,12 @@ void testForce(){
   JSPEC_ASSERT_THROW( abs(slope) < 1e-28 );
   
     
+  SetupModel(ForceFormula::MESHKOV);
+  data_path = CMAKE_SOURCE_DIR + std::string("/data/dumpMesh.txt");
+  test_path = CMAKE_SOURCE_DIR + std::string("/build/tests/Meshkov.txt");
+  slope = CompareOutput(data_path,test_path);
+  JSPEC_ASSERT_THROW( abs(slope) < 1e-27 );
+    
   JSPEC_TEST_END();
 
   //TODO: Clean up after our test, delete the test files  

--- a/tests/test_jspec.cc
+++ b/tests/test_jspec.cc
@@ -615,23 +615,23 @@ int dynamicboth(){
 int main(int, char**)
 {
 
-    /*
+    
     double check_rates[3];
     check_rates[0] = -0.0087216;
     check_rates[1] = -0.00907129;
     check_rates[2] = -0.0191686;
     ecool(ForceFormula::PARKHOMCHUK,check_rates);
 
-    check_rates[0] = -0.00503489;
-    check_rates[1] = -0.00544656;
-    check_rates[2] = -0.0122515;   
+    check_rates[0] = -0.00437511;//-0.00503489;
+    check_rates[1] = -0.00466975;//-0.00544656;
+    check_rates[2] = -0.0103422;//-0.0122515;   
     ecool(ForceFormula::DERBENEVSKRINSKY,check_rates);
-*/
 
-//    check_rates[0] = -1.72854;
-//    check_rates[1] = -1.72863;
-//    check_rates[2] = -2.61073;    
-//    ecool(ForceFormula::MESHKOV,check_rates);
+
+    check_rates[0] = -0.164163;//-1.72854;
+    check_rates[1] = -0.163062;//-1.72863;
+    check_rates[2] = -0.277927;//-2.61073;    
+    ecool(ForceFormula::MESHKOV,check_rates);
 
 //    dynamicibsbunched();
 //    dynamicibs();

--- a/tests/test_jspec.cc
+++ b/tests/test_jspec.cc
@@ -628,9 +628,9 @@ int main(int, char**)
     ecool(ForceFormula::DERBENEVSKRINSKY,check_rates);
 
 
-    check_rates[0] = -0.164163;//-1.72854;
-    check_rates[1] = -0.163062;//-1.72863;
-    check_rates[2] = -0.277927;//-2.61073;    
+    check_rates[0] = -0.168594;//-1.72854;
+    check_rates[1] = -0.167933;//-1.72863;
+    check_rates[2] = -0.286098;//-2.61073;    
     ecool(ForceFormula::MESHKOV,check_rates);
 
 //    dynamicibsbunched();


### PR DESCRIPTION
This uses the new model definition pattern to add the Meshkov asymptotic model as an option. This pattern automatically defines the testing output file, and automatically comes with OpenMP support for parallel friction force calculation. Minimal changes are required in the ui.cc and dynamic.cc functions, as the friction_force function in force.cc handles the switching. The 3 Coulomb logs calculated for this model have a fixed lower limit of 0.


I removed some commented testing code and added some explanatory comments.
